### PR TITLE
Increase method length to 20

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -76,7 +76,7 @@ Layout/LineLength:
 
 Metrics/MethodLength:
   Enabled: true
-  Max: 12
+  Max: 20
   Exclude:
     - "db/**/*"
 


### PR DESCRIPTION
* as the for formatting reasons, it's often that a single call with many parameters is split into many lines which quickly exhausts the current allowance of 12